### PR TITLE
when emergency category changes, the emergency code chosen will nullify

### DIFF
--- a/app/src/main/java/com/cbdn/reports/ui/views/inputemergency/InputEmergency.kt
+++ b/app/src/main/java/com/cbdn/reports/ui/views/inputemergency/InputEmergency.kt
@@ -1,5 +1,9 @@
 package com.cbdn.reports.ui.views.inputemergency
 
+// UI elements on this page and their logic adapted from previous
+// group's efforts in DispatchDetails.kt
+// Peter Judge - 3/1/2024
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -105,7 +109,12 @@ fun InputEmergency(
                 codeCategories.forEachIndexed { index, label ->
                     SegmentedButton(
                         selected = index == uiState.categoryIndex,
-                        onClick = { appViewModel.setCategoryIndex(index) },
+                        onClick = {
+                            if (index != uiState.categoryIndex){
+                                appViewModel.setEmergencyCode("")
+                            }
+                            appViewModel.setCategoryIndex(index)
+                                  },
                         shape = SegmentedButtonDefaults.itemShape(
                             index = index,
                             count = codeCategories.size),

--- a/app/src/main/java/com/cbdn/reports/ui/views/newreport/DispatchDetails.kt
+++ b/app/src/main/java/com/cbdn/reports/ui/views/newreport/DispatchDetails.kt
@@ -85,7 +85,12 @@ fun DispatchDetails(
             codeCategories.forEachIndexed { index, label ->
                 SegmentedButton(
                     selected = index == uiState.categoryIndex,
-                    onClick = { viewModel.setCategoryIndex(index) },
+                    onClick = {
+                        if (index != uiState.categoryIndex){
+                            viewModel.setEmergencyCode("")
+                        }
+                        viewModel.setCategoryIndex(index)
+                              },
                     shape = SegmentedButtonDefaults.itemShape(
                         index = index,
                         count = codeCategories.size),


### PR DESCRIPTION
When a user changed the emergency category, the chosen emergency code related to the old category was still saved in state, allowing for a potential mismatch of emergency code and category. This nulls it out instead so the user can only choose emergency codes that are only related to the proper category